### PR TITLE
Remove copy doc libs task from default build task.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,7 @@ gulp.task('watch', ['build'], function (done) {
 });
 
 // copy the demo.html files to the docs folder, rename them as 'comonent-name.html'
-gulp.task('docs',['docs:copy-libs'], function()
+gulp.task('docs', function()
 {
     return gulp.src('./components/*/demo.html')
     .pipe(rename(function(path) {


### PR DESCRIPTION
# Summary of Changes

This will get rid of the docs clutter in our commits, but will require us to do a manual `gulp docs:copy-libs` when we want to update the docs dependencies (which isn't a big deal).

*What did you change? If this is a bug fix, how did you fix it?*

Removes `docs:copy-libs` as a dependency from the `docs` task in the gulpfile.  This will prevent the contents of `docs/libs` from changing when we don't mean for it to do so.

# Browser Testing

**I have tested these changes in:**

N/A - Build-time changes only.

## Desktop Browsers

- [ ] Google Chrome
- [ ] Mozilla Firefox
- [ ] Apple Safari
- [ ] Microsoft Edge
- [ ] Microsoft Internet Explorer 11
- [ ] Other (please specify)

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android
- [ ] Other (please specify)

**We support the last two versions of Chrome, Firefox, Safari, and Edge,
plus Internet Explorer 11.**



