### PR TITLE
Change local docs component loading

### DIFF
--- a/docs/load-components.js
+++ b/docs/load-components.js
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+"use strict";
 
 /**
  * This isn't how you would typically load up the components, but it helps the developers in their local testing.
@@ -30,7 +31,7 @@
     var root = '//cdn.byu.edu/byu-theme-components/latest';
     var min = true;
 
-    var isLocalhost = window.location.hostname === 'localhost';
+    var isLocalhost = isLocalhost();
     var isForced = window.location.search && window.location.search.indexOf('load-local=true') >= 0;
 
     if (isLocalhost || isForced) {
@@ -58,5 +59,12 @@
         }
         u += '.' + extension;
         return u;
+    }
+
+    function isLocalhost() {
+        var host = window.location.hostname;
+        if (host === 'localhost') return true;
+
+        return /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.test(host);
     }
 })();


### PR DESCRIPTION
# Summary of Changes

Now, if you're accessing the docs via a raw IP or localhost, you'll get
it served to you from your local dist/ folder instead of from the CDN.
This makes working with VMs or testing with mobile devices easier!

# Browser Testing

**I have tested these changes in:**

*Add an x in all the boxes that apply. Please mark desktop and mobile
browsers separately.*

## Desktop Browsers

- [x] Google Chrome
- [ ] Mozilla Firefox
- [ ] Apple Safari
- [ ] Microsoft Edge
- [ ] Microsoft Internet Explorer 11
- [ ] Other (please specify)

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android
- [ ] Other (please specify)

**We support the last two versions of Chrome, Firefox, Safari, and Edge,
plus Internet Explorer 11.**



