### PR TITLE
No overflow

### DIFF
--- a/components/byu-footer/byu-footer.scss
+++ b/components/byu-footer/byu-footer.scss
@@ -1,7 +1,5 @@
 @import "byu-footer-common";
-html, body{
-width:100%;
-}
+
 .university-footer {
   background-color: $universityFooterBgColor;
   text-align: center;

--- a/components/byu-footer/byu-footer.scss
+++ b/components/byu-footer/byu-footer.scss
@@ -1,5 +1,7 @@
 @import "byu-footer-common";
-
+html, body{
+width:100%;
+}
 .university-footer {
   background-color: $universityFooterBgColor;
   text-align: center;
@@ -27,16 +29,15 @@
 }
 
 .university-logo-wrapper {
-  max-width: 1200px;
-  width: 100%;
-  padding: 0 8px;
+    max-width: 1200px;
+    width: 100%;
+    padding: 0; 
 }
-
 .university-logo {
-  max-width: 100%;
-  width: $universityFooterLogoWidth;
-  height: $universityFooterLogoHeight;
-  margin: -$universityFooterLogoVerticalOffset 0;
+    max-width: 450px;
+    width: 100%;
+    height: 40px;
+    margin: -10px 0;
 }
 
 .university-info {

--- a/components/byu-footer/byu-footer.scss
+++ b/components/byu-footer/byu-footer.scss
@@ -29,15 +29,17 @@ width:100%;
 }
 
 .university-logo-wrapper {
-    max-width: 1200px;
-    width: 100%;
-    padding: 0; 
+  max-width: 1200px;
+  width: 100%;
+  padding: 0 8px;
+  box-sizing: border-box;
 }
+
 .university-logo {
-    max-width: 450px;
-    width: 100%;
-    height: 40px;
-    margin: -10px 0;
+  max-width: 100%;
+  width: $universityFooterLogoWidth;
+  height: $universityFooterLogoHeight;
+  margin: -$universityFooterLogoVerticalOffset 0;
 }
 
 .university-info {


### PR DESCRIPTION
I've noticed some overflow issues with the footer

![overflow1](https://user-images.githubusercontent.com/18707957/28230066-acfb9082-68a2-11e7-93ba-44a809e97449.PNG)

The padding on .university-logo-wrapper will make every page that uses this component overflow.

![overflow2](https://user-images.githubusercontent.com/18707957/28230071-b0862f96-68a2-11e7-94a8-95a64b7429a5.PNG)


By simply removing this padding, it should resolve the issue on all of the other pages. Also, a better way of formatting the footer would be providing the .university-logo a width:100% and a max-width:450px, as well as giving the university-logo-wrapper a max-width of 1200px (or whatever the user desires) and a width of 100%. This will contain the size of the photo as well as supply a max width for both. 


 I also notice that the BYU Sample Theme site has more overflow issues due to the fact that the HTML and body have a width:100vw; and max-width: 100vw; if you switched this to only have a width:100%; it will get rid of unnecessary overflow.

The results can be seen below

no padding with 100vw on html,body
![overflow-without-padding](https://user-images.githubusercontent.com/18707957/28230077-b7cf2168-68a2-11e7-8d29-cc27bf040883.PNG)

no padding and 100% instead of 100vw
![overflow-without-vw](https://user-images.githubusercontent.com/18707957/28230082-b9a875c0-68a2-11e7-86ad-5c697d1edec4.PNG)




