### PR TITLE
Footer font  - Fixes 272

### DIFF
--- a/components/byu-footer-column/byu-footer-column-common.scss
+++ b/components/byu-footer-column/byu-footer-column-common.scss
@@ -36,6 +36,8 @@
 @mixin defaultContentLink() {
     text-decoration: none !important;
     outline: none !important;
+    color: #666666;
+    font-size: 14px;
 }
 
 @mixin defaultContentLinkHover() {

--- a/components/byu-footer-column/byu-footer-column-common.scss
+++ b/components/byu-footer-column/byu-footer-column-common.scss
@@ -43,4 +43,5 @@
 @mixin defaultContentLinkHover() {
     cursor: pointer;
     color: $navy !important;
+    font-size: 14px;
 }


### PR DESCRIPTION
# Summary of Changes

**Fixes Issue #272**

*What did you change? If this is a bug fix, how did you fix it?*
Added the correct font size and color. Currently, we can't change the font on hover because it will cause content reflow. We will need to address the font in the next release.
<img width="225" alt="screen shot 2017-07-17 at 10 59 07 am" src="https://user-images.githubusercontent.com/9389424/28279856-10cadce2-6adf-11e7-9b84-c9a041c0cce4.png">
<img width="223" alt="screen shot 2017-07-17 at 10 59 37 am" src="https://user-images.githubusercontent.com/9389424/28279860-152a0466-6adf-11e7-88cc-40c1994bafc9.png">


# Browser Testing

**I have tested these changes in:**

*Add an x in all the boxes that apply. Please mark desktop and mobile
browsers separately.*

## Desktop Browsers

- [ ] Google Chrome
- [ ] Mozilla Firefox
- [ ] Apple Safari
- [ ] Microsoft Edge
- [ ] Microsoft Internet Explorer 11
- [ ] Other (please specify)

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android
- [ ] Other (please specify)

**We support the last two versions of Chrome, Firefox, Safari, and Edge,
plus Internet Explorer 11.**



