### PR TITLE
Add CDN preload config

### DIFF
--- a/.cdn-config.yml
+++ b/.cdn-config.yml
@@ -1,12 +1,24 @@
 ---
-name: 2017 Theme Core Components
+name: Theme Header/Footer Components
 description: Header and Footer components for 2017 Theme
 resources:
   - src: dist/**
     dest: ./
-entrypoints:
-  byu-theme-components.js: 'Examines browser support and downloads the appropriate component bundle'
-  byu-theme-components.min.js: 'Minified - Examines browser support and downloads the appropriate component bundle'
-  byu-theme-components.css: 'Main CSS file'
-  byu-theme-components.min.css: 'Main CSS file'
 docs: https://github.com/byuweb/byu-theme-components
+type: 'web-component'
+preload:
+  byu-theme-components.min.css:
+  - lib: shared-icons
+    version: latest
+    file: logos/monogram-white.svg
+  - lib: theme-fonts
+    version: latest
+    file: ringside/fonts.css
+  byu-theme-components.min.js:
+  - ./components.min.js
+  - lib: shared-icons
+    version: latest
+    file: logos/monogram-white.svg
+  - lib: theme-fonts
+    version: latest
+    file: ringside/fonts.css


### PR DESCRIPTION
This will cause the CDN to add preload links to its responses.  This allows for better performance in the browser, as the browser can start fetching resources immediately instead of having to wait to parse and execute the responses before it finds out what it needs next.

This feature has been stable in the production CDN for some time, so it's time to move the configs from the main CDN config to this repo.

Very little risk involved in this change, as the config has already been being applied by the main CDN config, and browsers that don't support preload links will just ignore them entirely.