### PR TITLE
Fix font preload link in CDN config

### DIFF
--- a/.cdn-config.yml
+++ b/.cdn-config.yml
@@ -12,7 +12,7 @@ preload:
     version: latest
     file: logos/monogram-white.svg
   - lib: theme-fonts
-    version: latest
+    version: 1.x.x
     file: ringside/fonts.css
   byu-theme-components.min.js:
   - ./components.min.js


### PR DESCRIPTION
# Summary of Changes

Fixes the URL of the preload link the CDN sends for the Ringside font file.
