### PR TITLE
Added documentation for double-wide footer in tablet view

### DIFF
--- a/docs/byu-footer.html
+++ b/docs/byu-footer.html
@@ -233,6 +233,25 @@
             </template>
         </demo-snippet>
 
+        <p>
+            Remember that the footer shifts in tablet and mobile views to stack in a 2x2 and 1x4 block.
+            If you use a double-wide column in the middle (columns 2 & 3), it will stack strangely in tablet-width.
+            To adjust for this, you can add the following snippet to your CSS to place your double-wide column in
+            the second row underneath your 1st and 4th columns.
+        </p>
+
+        <pre><code class="language-css">
+            @media (min-width: 600px) {
+                byu-footer-column.double-wide {
+                    order: 1;
+                }
+
+                .site-footer ::slotted(*) {
+                    width: unset;
+                }
+            }
+        </code></pre>
+
         <demo-snippet>
             <template>
                 <byu-footer>


### PR DESCRIPTION
# Summary of Changes

**Fixes Issue #422**

Added documentation to http://2017-components-demo.cdn.byu.edu/byu-footer.html for adjusting the footer when a double-wide column is used in the middle (so it stacks properly in tablet-view).

CSS added to documentation would have the following effect in tablet-view:

BEFORE
![image](https://user-images.githubusercontent.com/25965299/48795582-986aac00-ecba-11e8-9248-41e949e1336c.png)

AFTER
![image](https://user-images.githubusercontent.com/25965299/48795537-75d89300-ecba-11e8-869d-a7f980c2f7dc.png)


# Browser Testing

**I have tested these changes in:**

*Add an x in all the boxes that apply. Please mark desktop and mobile
browsers separately.*

## Desktop Browsers

- [ ] Google Chrome
- [ ] Mozilla Firefox
- [ ] Apple Safari
- [ ] Microsoft Edge
- [ ] Other (please specify)

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android
- [ ] Other (please specify)

**We support the last two versions of Chrome, Firefox, Safari, and Edge.**



