### PR TITLE
Added color CSS to social icons in FOUC

### DIFF
--- a/components/byu-footer/byu-footer-fouc.sass
+++ b/components/byu-footer/byu-footer-fouc.sass
@@ -112,6 +112,7 @@ byu-footer:not(.byu-component-rendered)
         height: 18px
         width: 18px
         text-indent: -99999em
+        fill: #3b5998
 
       .instagram
         content: ""
@@ -119,6 +120,7 @@ byu-footer:not(.byu-component-rendered)
         height: 18px
         width: 18px
         text-indent: -99999em
+        fill: #c32aa3
 
       .twitter
         content: ""
@@ -126,6 +128,7 @@ byu-footer:not(.byu-component-rendered)
         height: 18px
         width: 18px
         text-indent: -99999em
+        fill: #1da1f2
 
       .linkedin
         content: ""
@@ -133,6 +136,7 @@ byu-footer:not(.byu-component-rendered)
         height: 18px
         width: 18px
         text-indent: -99999em
+        fill: #007bb5
 
       .youtube
         content: ""
@@ -140,6 +144,7 @@ byu-footer:not(.byu-component-rendered)
         height: 18px
         width: 18px
         text-indent: -99999em
+        fill: red
 
   @media( max-width: $breakMdLg )
     grid-template: repeat(2, min-content) 56px / auto repeat(2,50%) auto


### PR DESCRIPTION
# Summary of Changes

**Fixes Issue #480 **

*What did you change? If this is a bug fix, how did you fix it?*
Uploaded new SVG icon files to the shared-icons repo. Added CSS in byu-footer FOUC to add colors to SVGs

**If this fixes styling, please include before and after screenshots!**

# Browser Testing

**I have tested these changes in:**

*Add an x in all the boxes that apply. Please mark desktop and mobile
browsers separately.*

## Desktop Browsers

- [ ] Google Chrome
- [ ] Mozilla Firefox
- [ ] Apple Safari
- [ ] Microsoft Edge
- [ ] Other (please specify)

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android
- [ ] Other (please specify)

**We support the last two versions of Chrome, Firefox, Safari, and Edge.**



