### PR TITLE
fix: remove automatically setting background to white

### DIFF
--- a/components/byu-theme-components.sass
+++ b/components/byu-theme-components.sass
@@ -35,4 +35,3 @@ html
 body
   margin: 0
   padding: 0
-  background-color: #FAFAFA


### PR DESCRIPTION
# Summary of Changes

*What did you change? If this is a bug fix, how did you fix it?*

The documentation already specifies that the developer should take care to use FAFAFA for the background. Doing it for them interferes with switching between a dark and light theme.

**If this fixes styling, please include before and after screenshots!**

# Browser Testing

**I have tested these changes in:**

*Add an x in all the boxes that apply. Please mark desktop and mobile
browsers separately.*

## Desktop Browsers

- [ ] Google Chrome
- [ ] Mozilla Firefox
- [ ] Apple Safari
- [ ] Microsoft Edge

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android

**We support the last two versions of Chrome, Firefox, Safari, and Edge.**



