### PR TITLE
changing paid fonts out for Google font chosen by Brand and Creative

### DIFF
--- a/components/byu-theme-components.sass
+++ b/components/byu-theme-components.sass
@@ -16,9 +16,9 @@
 
 @import shared-styles/vars
 
-@import "https://cdn.byu.edu/theme-fonts/1.x.x/ringside/fonts.css"
-
-@import "https://cdn.byu.edu/theme-fonts/1.x.x/public-sans/fonts.css"
+// @import "https://cdn.byu.edu/theme-fonts/1.x.x/ringside/fonts.css"
+// @import "https://cdn.byu.edu/theme-fonts/1.x.x/public-sans/fonts.css"
+  @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&display=swap')
 
 // FOUC Styles
 @import byu-header/byu-header-fouc

--- a/components/shared-styles/vars.sass
+++ b/components/shared-styles/vars.sass
@@ -14,8 +14,9 @@
  /    limitations under the License.
  /
 
-@import "https://cdn.byu.edu/theme-fonts/1.x.x/ringside/fonts.css"
-@import "https://cdn.byu.edu/theme-fonts/1.x.x/public-sans/fonts.css"
+// @import "https://cdn.byu.edu/theme-fonts/1.x.x/ringside/fonts.css"
+// @import "https://cdn.byu.edu/theme-fonts/1.x.x/public-sans/fonts.css"
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&display=swap')
 
 /*
  * Corner Radius
@@ -100,9 +101,9 @@ $fontSize64: 4em / $baseFontMultiplier
 
 // Styles
 
-$font-heading: 'HCo Ringside Narrow SSm', 'Open Sans', Helvetica, Arial, sans-serif
-$font-text: 'Public Sans', 'Noto Sans', 'Open Sans', Helvetica, Arial, sans-serif
-$font-mono: 'Noto Mono', 'Roboto Mono', monospace
+$font-heading: "IBM Plex Sans", "Open Sans", Helvetica, Arial, sans-serif
+$font-text: "IBM Plex Sans", "Open Sans", Helvetica, Arial, sans-serif
+$font-mono: "IBM Plex Sans", 'Roboto Mono', monospace
 
 // Weight
 $font-weight-normal: 400


### PR DESCRIPTION
# Summary of Changes
Replaced HCO Ringside and Noto with IBM Plex Sans per Brand and Creative
**Fixes Issue #(Add issue number here)**
No issue number
*What did you change? If this is a bug fix, how did you fix it?*
Changed font import and related font variables
**If this fixes styling, please include before and after screenshots!**

# Browser Testing

**I have tested these changes in:**

*Add an x in all the boxes that apply. Please mark desktop and mobile
browsers separately.*

## Desktop Browsers

- [ ] Google Chrome
- [ ] Mozilla Firefox
- [ ] Apple Safari
- [ ] Microsoft Edge

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android

**We support the last two versions of Chrome, Firefox, Safari, and Edge.**



